### PR TITLE
Add deduplication of routes generated by honoring the I18n.fallbacks

### DIFF
--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -13,10 +13,12 @@ module RouteTranslator
 
   DEFAULT_CONFIGURATION = {
     available_locales:                   [],
+    fallback_locales:                    [],
     disable_fallback:                    false,
     force_locale:                        false,
     generate_unlocalized_routes:         false,
     generate_unnamed_unlocalized_routes: false,
+    deduplicate_routes:                  false,
     hide_locale:                         false,
     host_locales:                        {},
     locale_param_key:                    :locale,
@@ -63,6 +65,16 @@ module RouteTranslator
 
     if locales.empty?
       I18n.available_locales.dup
+    else
+      locales.map(&:to_sym)
+    end
+  end
+
+  def fallback_locales
+    locales = config.fallback_locales
+
+    if locales.empty?
+      @fallback_locales ||= I18n.fallbacks.reduce([]) { |acc, entry| acc.push(entry.last.reject { |fallback| fallback == entry.first })  }.flatten.uniq
     else
       locales.map(&:to_sym)
     end

--- a/lib/route_translator.rb
+++ b/lib/route_translator.rb
@@ -74,7 +74,7 @@ module RouteTranslator
     locales = config.fallback_locales
 
     if locales.empty?
-      @fallback_locales ||= I18n.fallbacks.reduce([]) { |acc, entry| acc.push(entry.last.reject { |fallback| fallback == entry.first })  }.flatten.uniq
+      I18n.fallbacks.values.map(&:last).uniq
     else
       locales.map(&:to_sym)
     end

--- a/lib/route_translator/extensions/route_set.rb
+++ b/lib/route_translator/extensions/route_set.rb
@@ -8,7 +8,7 @@ module ActionDispatch
       def add_localized_route(mapping, name, anchor, scope, path, controller, default_action, to, via, formatted, options_constraints, options)
         route = RouteTranslator::Route.new(self, path, name, options_constraints, options, mapping)
 
-        RouteTranslator::Translator.translations_for(route) do |locale, translated_name, translated_path, translated_options_constraints, translated_options|
+        RouteTranslator::Translator.deduplicated_translations_for(route) do |locale, translated_name, translated_path, translated_options_constraints, translated_options|
           translated_path_ast = ::ActionDispatch::Journey::Parser.parse(translated_path)
           translated_mapping  = translate_mapping(locale, self, translated_options, translated_path_ast, scope, controller, default_action, to, formatted, via, translated_options_constraints, anchor)
 

--- a/lib/route_translator/extensions/route_set.rb
+++ b/lib/route_translator/extensions/route_set.rb
@@ -8,7 +8,7 @@ module ActionDispatch
       def add_localized_route(mapping, name, anchor, scope, path, controller, default_action, to, via, formatted, options_constraints, options)
         route = RouteTranslator::Route.new(self, path, name, options_constraints, options, mapping)
 
-        RouteTranslator::Translator.deduplicated_translations_for(route) do |locale, translated_name, translated_path, translated_options_constraints, translated_options|
+        translations_for(route) do |locale, translated_name, translated_path, translated_options_constraints, translated_options|
           translated_path_ast = ::ActionDispatch::Journey::Parser.parse(translated_path)
           translated_mapping  = translate_mapping(locale, self, translated_options, translated_path_ast, scope, controller, default_action, to, formatted, via, translated_options_constraints, anchor)
 
@@ -23,6 +23,14 @@ module ActionDispatch
       end
 
       private
+
+      def translations_for(route, &block)
+        if RouteTranslator.config.deduplicate_routes
+          RouteTranslator::Translator.deduplicated_translations_for(route, &block)
+        else
+          RouteTranslator::Translator.translations_for(route, &block)
+        end
+      end
 
       def translate_mapping(locale, route_set, translated_options, translated_path_ast, scope, controller, default_action, to, formatted, via, translated_options_constraints, anchor)
         scope_params = {

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -49,6 +49,14 @@ module RouteTranslator
       rescue I18n::MissingTranslationData => e
         raise e unless RouteTranslator.config.disable_fallback
       end
+
+      def allowed_to_deduplicate(locale, translated_path, generated_routes)
+        return false unless RouteTranslator.config.deduplicate_routes
+        return false if RouteTranslator.fallback_locales.include?(locale)
+        return false if I18n.default_locale == locale
+        
+        generated_routes[translated_path]
+      end
     end
 
     module_function
@@ -65,16 +73,22 @@ module RouteTranslator
     def translations_for(route)
       RouteTranslator::Translator::RouteHelpers.add route.name, route.route_set.named_routes
 
+      generated_routes = {}
+
       available_locales.each do |locale|
         translated_path = translate_path(route.path, locale, route.scope)
         next unless translated_path
+        next if allowed_to_deduplicate(locale, translated_path, generated_routes)
 
         translated_name                = translate_name(route.name, locale, route.route_set.named_routes.names)
         translated_options_constraints = translate_options_constraints(route.options_constraints, locale)
         translated_options             = translate_options(route.options, locale)
+        generated_routes[translated_path] = true
 
         yield locale, translated_name, translated_path, translated_options_constraints, translated_options
       end
+
+      generated_routes = nil
     end
 
     def route_name_for(args, old_name, suffix, kaller)
@@ -85,11 +99,25 @@ module RouteTranslator
                  args_locale.to_s.underscore
                elsif kaller.respond_to?("#{old_name}_#{current_locale_name}_#{suffix}")
                  current_locale_name
+               elsif fallback_locale = fallback_route_locale_name(current_locale_name, old_name, suffix, kaller)
+                 fallback_locale
                else
                  I18n.default_locale.to_s.underscore
                end
 
       "#{old_name}_#{locale}_#{suffix}"
+    end
+
+    def fallback_route_locale_name(current_locale_name, old_name, suffix, kaller)
+      return nil unless RouteTranslator.config.deduplicate_routes
+      
+      available_fallback_locales = I18n.fallbacks[current_locale_name].select do |fallback_locale|
+        kaller.respond_to?("#{old_name}_#{fallback_locale}_#{suffix}")
+      end
+
+      return nil if available_fallback_locales.empty?
+
+      available_fallback_locales.first
     end
   end
 end

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -63,6 +63,8 @@ module RouteTranslator
 
     def available_locales
       locales = RouteTranslator.available_locales
+      return locales if RouteTranslator.config.deduplicate_routes
+
       # Make sure the default locale is translated in last place to avoid
       # problems with wildcards when default locale is omitted in paths. The
       # default routes will catch all paths like wildcard if it is translated first.

--- a/lib/route_translator/translator.rb
+++ b/lib/route_translator/translator.rb
@@ -52,12 +52,12 @@ module RouteTranslator
 
       def allowed_to_deduplicate(locale, translated_path, generated_routes)
         return false unless RouteTranslator.config.deduplicate_routes
-        return false if RouteTranslator.fallback_locales.include?(locale)
         return false if I18n.default_locale == locale
-        return false unless generated_routes[translated_path]
-        return true if generated_routes[translated_path].include?(I18n.default_locale)
-        
-        !generated_routes[translated_path].include?(locale)
+        return false if generated_routes[translated_path].nil? || generated_routes[translated_path].empty?
+        return true if generated_routes[translated_path] && !generated_routes[translated_path].empty?
+        return false if RouteTranslator.fallback_locales.include?(locale)
+
+        true
       end
     end
 
@@ -103,8 +103,6 @@ module RouteTranslator
       sorted_available_locales_for_deduplication.each do |locale|
         translated_path = translate_path(route.path, locale, route.scope)
         next unless translated_path
-        puts "DETECT: #{locale} -> #{translated_path} -> #{allowed_to_deduplicate(locale, translated_path, generated_routes)}" if translated_path.include?('over-scholierenwerk')
-
         next if allowed_to_deduplicate(locale, translated_path, generated_routes)
 
         generated_routes[translated_path] ||= []
@@ -116,10 +114,7 @@ module RouteTranslator
       sorted_available_locales_for_routing_pass.each do |locale|
         translated_path = translate_path(route.path, locale, route.scope)
         next unless translated_path
-
-        # puts "#{allowed_to_deduplicate(locale, translated_path, generated_routes)} #{locale} -> #{translated_path}"
-        puts "ADD: #{locale} -> #{translated_path} -> #{allowed_to_deduplicate(locale, translated_path, generated_routes)}" if translated_path.include?('over-scholierenwerk')
-        next if allowed_to_deduplicate(locale, translated_path, generated_routes)
+        next unless generated_routes[translated_path].include?(locale)
 
         translated_name                = translate_name(route.name, locale, route.route_set.named_routes.names)
         translated_options_constraints = translate_options_constraints(route.options_constraints, locale)


### PR DESCRIPTION
This feature allows the developer to set their fallback locales and generate their routes all other routes will check if there is an existing route (one of the fallbacks) and if so it skips it.

This reduces the amount of routes generated that can easily be deduplicated.